### PR TITLE
Enable environment parameter as default

### DIFF
--- a/mulesoft_discovery_agent/mulesoft_discovery_agent.yml
+++ b/mulesoft_discovery_agent/mulesoft_discovery_agent.yml
@@ -32,7 +32,7 @@ mulesoft:
   #anypointExchangeUrl: https://anypoint.mulesoft.com
   
   # The Mulesoft environment to connect to.
-  #environment: Sandbox
+  environment: Sandbox
   auth:
     # The credentials used to connect to Mulesoft
     username: <USERNAME>


### PR DESCRIPTION
As the Mulesoft `environment` parameter is a must have, it should be enabled by default in the YAML-Config file. It's already the case for the Traceability agent.