### PR TITLE
APIGOV-18625 Link observer traffic to service

### DIFF
--- a/default_mulesoft_discovery_agent.yml
+++ b/default_mulesoft_discovery_agent.yml
@@ -4,7 +4,6 @@ central:
   mode: publishToEnvironmentAndCatalog
   url: https://apicentral.axway.com
   platformURL: https://platform.axway.com
-  pollInterval: 10s
   auth:
     clientID: <Amplify_CENTRAL_DOSA_CLIENT_ID>
     privateKey: <Amplify_CENTRAL_DOSA_PRIVATE_KEY_PATH>

--- a/default_mulesoft_traceability_agent.yml
+++ b/default_mulesoft_traceability_agent.yml
@@ -15,7 +15,7 @@ mulesoft_traceability_agent:
 mulesoft:
   environment: Sandbox
   cachePath: "/tmp"
-  pollInterval: 30s
+  pollInterval: 20s
   auth:
     username: <USERNAME>
     password: <PASSWORD>

--- a/pkg/anypoint/authentication_test.go
+++ b/pkg/anypoint/authentication_test.go
@@ -17,11 +17,6 @@ func TestAuth(t *testing.T) {
 		err   error
 	}{
 		{
-			name:  "should return an access token and no error",
-			token: "abc123",
-			err:   nil,
-		},
-		{
 			name:  "should return no token and an error",
 			token: "",
 			err:   fmt.Errorf("no token here"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,7 +103,7 @@ func AddConfigProperties(props properties.Properties) {
 	props.AddStringProperty(pathDiscoveryTags, "", "APIs containing any of these tags are selected for discovery.")
 	props.AddStringProperty(pathDiscoveryIgnoreTags, "", "APIs containing any of these tags are ignored. Takes precedence over "+pathDiscoveryIgnoreTags+".")
 	props.AddStringProperty(pathCachePath, "/tmp", "Mulesoft Cache Path")
-	props.AddDurationProperty(pathPollInterval, 30*time.Second, "The interval at which Mulesoft is checked for updates.")
+	props.AddDurationProperty(pathPollInterval, 20*time.Second, "The interval at which Mulesoft is checked for updates.")
 
 	// ssl properties and command flags
 	props.AddStringSliceProperty(pathSSLNextProtos, []string{}, "List of supported application level protocols, comma separated.")

--- a/pkg/discovery/agent_test.go
+++ b/pkg/discovery/agent_test.go
@@ -62,7 +62,11 @@ func TestAgent_Run(t *testing.T) {
 	assert.True(t, discRunning)
 	pubRunning := <-pub.hitCh
 	assert.True(t, pubRunning)
-	a.Stop()
+	go a.Stop()
+	done := <-disc.stopCh
+	assert.True(t, done)
+	done = <-pub.stopCh
+	assert.True(t, done)
 }
 
 func Test_validateAPI(t *testing.T) {

--- a/pkg/discovery/discover_test.go
+++ b/pkg/discovery/discover_test.go
@@ -34,7 +34,7 @@ var asset = anypoint.Asset{
 	AutodiscoveryAPIName: "groupId:d3ada710-fc7b-4fc7-b8b9-4ccfc0f872e4:assetId:petstore-3",
 	ExchangeAssetName:    "petstore-3",
 	GroupID:              "d3ada710-fc7b-4fc7-b8b9-4ccfc0f872e4",
-	ID:                   211799904,
+	ID:                   16810512,
 	MasterOrganizationID: "d3ada710-fc7b-4fc7-b8b9-4ccfc0f872e4",
 	Name:                 "groupId:d3ada710-fc7b-4fc7-b8b9-4ccfc0f872e4:assetId:petstore-3",
 	OrganizationID:       "d3ada710-fc7b-4fc7-b8b9-4ccfc0f872e4",

--- a/pkg/discovery/discover_test.go
+++ b/pkg/discovery/discover_test.go
@@ -115,15 +115,9 @@ func Test_discoverAPIs(t *testing.T) {
 			}
 			go disc.discoverAPIs()
 
-			calls := 0
-			for calls < tc.expectedAssets {
-				select {
-				case <-disc.apiChan:
-					calls++
-				}
-			}
+			svc := <-disc.apiChan
 
-			assert.Equal(t, tc.expectedAssets, calls)
+			assert.Equal(t, sd, svc)
 			logrus.Info(client)
 		})
 	}

--- a/pkg/discovery/publish.go
+++ b/pkg/discovery/publish.go
@@ -30,6 +30,7 @@ func (p *publisher) Loop() {
 		case serviceDetail := <-p.apiChan:
 			p.publish(serviceDetail)
 		case <-p.stopPublish:
+			log.Debug("stopping publish listener")
 			return
 		}
 	}

--- a/pkg/discovery/publish_test.go
+++ b/pkg/discovery/publish_test.go
@@ -43,18 +43,11 @@ func TestPublish(t *testing.T) {
 	}
 	go pub.Loop()
 	// send 3 events to the channel
-	for i := 0; i < 3; i++ {
-		pub.apiChan <- sd
-	}
+	pub.apiChan <- sd
 
-	// wait for each event
-	for mp.count < 3 {
-		select {
-		case <-mp.hitCh:
-		}
-	}
+	isDone := <-mp.hitCh
 
-	assert.Equal(t, 3, mp.count)
+	assert.True(t, isDone)
 	pub.OnConfigChange(&config.MulesoftConfig{})
 	pub.Stop()
 }

--- a/pkg/traceability/eventmapper.go
+++ b/pkg/traceability/eventmapper.go
@@ -101,12 +101,14 @@ func (em *EventMapper) createSummaryEvent(
 	name := event.APIName
 	statusCode := event.StatusCode
 	uri := event.ResourcePath
-	version := event.APIVersionName
+
+	// must be the same as the the 'externalAPIID' attribute set on the APIService.
+	apiVersionID := event.APIVersionID
 
 	return transaction.NewTransactionSummaryBuilder().
 		SetDuration(event.ResponseTime).
 		SetEntryPoint("http", method, uri, host).
-		SetProxy(transaction.FormatProxyID(version), name, 1).
+		SetProxy(transaction.FormatProxyID(apiVersionID), name, 1).
 		SetStatus(getTransactionSummaryStatus(statusCode), strconv.Itoa(statusCode)).
 		SetTeam(teamID).
 		SetTransactionID(txID).

--- a/pkg/traceability/eventmapper_test.go
+++ b/pkg/traceability/eventmapper_test.go
@@ -116,7 +116,7 @@ func Test_APIServiceNameAndTransactionProxyNameAreEqual(t *testing.T) {
 		AuthPolicy:        "pass-through",
 		Description:       "petstore api",
 		Documentation:     nil,
-		ID:                "211799904",
+		ID:                "16810512",
 		Image:             "",
 		ImageContentType:  "",
 		ResourceType:      "oas3",
@@ -138,5 +138,7 @@ func Test_APIServiceNameAndTransactionProxyNameAreEqual(t *testing.T) {
 	le, err := em.createSummaryEvent(100, FormatTxnId(event.APIVersionID, event.MessageID), event, "123")
 	assert.Nil(t, err)
 	transactionProxyName := le.TransactionSummary.Proxy.Name
+	transactionProxyID := le.TransactionSummary.Proxy.ID
 	assert.Equal(t, apiServiceName, transactionProxyName)
+	assert.Equal(t, transaction.FormatProxyID(body.RestAPIID), transactionProxyID)
 }

--- a/pkg/traceability/eventmapper_test.go
+++ b/pkg/traceability/eventmapper_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var event = anypoint.AnalyticsEvent{
-	APIID:              "211799904",
+	APIID:              "16810512",
 	APIName:            "petstore-3",
 	APIVersionID:       "16810512",
 	APIVersionName:     "v1",

--- a/pkg/traceability/eventmapper_test.go
+++ b/pkg/traceability/eventmapper_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var event = anypoint.AnalyticsEvent{
-	APIID:              "16810512",
+	APIID:              "211799904",
 	APIName:            "petstore-3",
 	APIVersionID:       "16810512",
 	APIVersionName:     "v1",

--- a/pkg/traceability/eventprocessor_test.go
+++ b/pkg/traceability/eventprocessor_test.go
@@ -57,7 +57,7 @@ func TestEventProcessor_ProcessRaw(t *testing.T) {
 	assert.Equal(t, "200", summaryEvent.TransactionSummary.StatusDetail)
 	assert.Equal(t, 60, summaryEvent.TransactionSummary.Duration)
 	assert.Equal(t, TeamID, summaryEvent.TransactionSummary.Team.ID)
-	assert.Equal(t, transaction.FormatProxyID(event.APIVersionName), summaryEvent.TransactionSummary.Proxy.ID)
+	assert.Equal(t, transaction.FormatProxyID(event.APIID), summaryEvent.TransactionSummary.Proxy.ID)
 	assert.Equal(t, 1, summaryEvent.TransactionSummary.Proxy.Revision)
 	assert.Equal(t, event.APIName, summaryEvent.TransactionSummary.Proxy.Name)
 	assert.Nil(t, summaryEvent.TransactionSummary.Runtime)

--- a/pkg/traceability/eventprocessor_test.go
+++ b/pkg/traceability/eventprocessor_test.go
@@ -57,7 +57,7 @@ func TestEventProcessor_ProcessRaw(t *testing.T) {
 	assert.Equal(t, "200", summaryEvent.TransactionSummary.StatusDetail)
 	assert.Equal(t, 60, summaryEvent.TransactionSummary.Duration)
 	assert.Equal(t, TeamID, summaryEvent.TransactionSummary.Team.ID)
-	assert.Equal(t, transaction.FormatProxyID(event.APIID), summaryEvent.TransactionSummary.Proxy.ID)
+	assert.Equal(t, transaction.FormatProxyID(event.APIVersionID), summaryEvent.TransactionSummary.Proxy.ID)
 	assert.Equal(t, 1, summaryEvent.TransactionSummary.Proxy.Revision)
 	assert.Equal(t, event.APIName, summaryEvent.TransactionSummary.Proxy.Name)
 	assert.Nil(t, summaryEvent.TransactionSummary.Runtime)


### PR DESCRIPTION
Fix an issue where the observer traffic was unable to link to the correct api service when applying filters to the page in observer.