### PR TITLE
APIGOV-18873  Fix discovery of policies that have an array of configurations.

### DIFF
--- a/pkg/anypoint/types.go
+++ b/pkg/anypoint/types.go
@@ -89,19 +89,19 @@ type API struct {
 
 // Policy -
 type Policy struct {
-	APIID                int64                  `json:"apiId"`
-	Audit                Audit                  `json:"audit"`
-	Configuration        map[string]interface{} `json:"configuration"`
-	ID                   int64                  `json:"id"`
-	MasterOrganizationID string                 `json:"masterOrganizationId"`
-	Order                int                    `json:"order"`
-	OrganizationID       string                 `json:"organizationId"`
-	PointCutData         interface{}            `json:"pointCutData"`
-	PolicyID             int                    `json:"policyId"`
-	PolicyTemplateID     string                 `json:"policyTemplateId"`
-	Template             Template               `json:"template"`
-	Type                 string                 `json:"type"`
-	Version              int64                  `json:"version"`
+	APIID                int64       `json:"apiId"`
+	Audit                Audit       `json:"audit"`
+	Configuration        interface{} `json:"configuration"`
+	ID                   int64       `json:"id"`
+	MasterOrganizationID string      `json:"masterOrganizationId"`
+	Order                int         `json:"order"`
+	OrganizationID       string      `json:"organizationId"`
+	PointCutData         interface{} `json:"pointCutData"`
+	PolicyID             int         `json:"policyId"`
+	PolicyTemplateID     string      `json:"policyTemplateId"`
+	Template             Template    `json:"template"`
+	Type                 string      `json:"type"`
+	Version              int64       `json:"version"`
 }
 
 type Template struct {

--- a/pkg/discovery/mocks/mockCentralClient.go
+++ b/pkg/discovery/mocks/mockCentralClient.go
@@ -67,3 +67,7 @@ func (m *MockCentralClient) DeleteServiceByAPIID(string) error {
 func (m *MockCentralClient) GetConsumerInstancesByExternalAPIID(string) ([]*v1alpha1.ConsumerInstance, error) {
 	return nil, nil
 }
+
+func (m *MockCentralClient) GetUserName(id string) (string, error) {
+	return "", nil
+}

--- a/pkg/discovery/servicehandler.go
+++ b/pkg/discovery/servicehandler.go
@@ -353,15 +353,27 @@ func getSpecType(file *anypoint.ExchangeFile, specContent []byte) (string, error
 func getAuthPolicy(policies anypoint.Policies) (string, map[string]interface{}, bool) {
 	for _, policy := range policies.Policies {
 		if policy.Template.AssetID == anypoint.ClientID {
-			return apic.Apikey, policy.Configuration, false
+			conf, ok := policy.Configuration.(map[string]interface{})
+			if !ok {
+				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
+			}
+			return apic.Apikey, conf, false
 		}
 
 		if strings.Contains(policy.Template.AssetID, anypoint.SlaAuth) {
-			return apic.Apikey, policy.Configuration, true
+			conf, ok := policy.Configuration.(map[string]interface{})
+			if !ok {
+				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
+			}
+			return apic.Apikey, conf, true
 		}
 
 		if policy.Template.AssetID == anypoint.ExternalOauth {
-			return apic.Oauth, policy.Configuration, false
+			conf, ok := policy.Configuration.(map[string]interface{})
+			if !ok {
+				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
+			}
+			return apic.Oauth, conf, false
 		}
 	}
 

--- a/pkg/discovery/servicehandler.go
+++ b/pkg/discovery/servicehandler.go
@@ -353,29 +353,17 @@ func getSpecType(file *anypoint.ExchangeFile, specContent []byte) (string, error
 func getAuthPolicy(policies anypoint.Policies) (string, map[string]interface{}, bool) {
 	for _, policy := range policies.Policies {
 		if policy.Template.AssetID == anypoint.ClientID {
-			conf, ok := policy.Configuration.(map[string]interface{})
-			if !ok {
-				conf = map[string]interface{}{}
-				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
-			}
+			conf := getMapFromInterface(policy.Configuration)
 			return apic.Apikey, conf, false
 		}
 
 		if strings.Contains(policy.Template.AssetID, anypoint.SlaAuth) {
-			conf, ok := policy.Configuration.(map[string]interface{})
-			if !ok {
-				conf = map[string]interface{}{}
-				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
-			}
+			conf := getMapFromInterface(policy.Configuration)
 			return apic.Apikey, conf, true
 		}
 
 		if policy.Template.AssetID == anypoint.ExternalOauth {
-			conf, ok := policy.Configuration.(map[string]interface{})
-			if !ok {
-				conf = map[string]interface{}{}
-				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
-			}
+			conf := getMapFromInterface(policy.Configuration)
 			return apic.Oauth, conf, false
 		}
 	}
@@ -534,4 +522,13 @@ func isPublished(api *anypoint.API, authPolicy string, c cache.Cache) (bool, str
 	} else {
 		return true, checksum
 	}
+}
+
+func getMapFromInterface(generic interface{}) map[string]interface{} {
+	conf, ok := generic.(map[string]interface{})
+	if !ok {
+		logrus.Errorf("unable to perform type assertion on %#v", generic)
+		return map[string]interface{}{}
+	}
+	return conf
 }

--- a/pkg/discovery/servicehandler.go
+++ b/pkg/discovery/servicehandler.go
@@ -355,6 +355,7 @@ func getAuthPolicy(policies anypoint.Policies) (string, map[string]interface{}, 
 		if policy.Template.AssetID == anypoint.ClientID {
 			conf, ok := policy.Configuration.(map[string]interface{})
 			if !ok {
+				conf = map[string]interface{}{}
 				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
 			}
 			return apic.Apikey, conf, false
@@ -363,6 +364,7 @@ func getAuthPolicy(policies anypoint.Policies) (string, map[string]interface{}, 
 		if strings.Contains(policy.Template.AssetID, anypoint.SlaAuth) {
 			conf, ok := policy.Configuration.(map[string]interface{})
 			if !ok {
+				conf = map[string]interface{}{}
 				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
 			}
 			return apic.Apikey, conf, true
@@ -371,13 +373,14 @@ func getAuthPolicy(policies anypoint.Policies) (string, map[string]interface{}, 
 		if policy.Template.AssetID == anypoint.ExternalOauth {
 			conf, ok := policy.Configuration.(map[string]interface{})
 			if !ok {
+				conf = map[string]interface{}{}
 				logrus.Errorf("unable to perform type assertion on %#v", policy.Configuration)
 			}
 			return apic.Oauth, conf, false
 		}
 	}
 
-	return apic.Passthrough, nil, false
+	return apic.Passthrough, map[string]interface{}{}, false
 }
 
 func setWSDLEndpoint(_ string, specContent []byte) ([]byte, error) {

--- a/pkg/discovery/servicehandler.go
+++ b/pkg/discovery/servicehandler.go
@@ -177,10 +177,16 @@ func (s *serviceHandler) getServiceDetail(asset *anypoint.Asset, api *anypoint.A
 		return nil, err
 	}
 
+	status := apic.PublishedStatus
+	if api.Deprecated == true {
+		status = apic.DeprecatedStatus
+	}
+
 	return &ServiceDetail{
 		APIName:          api.AssetID,
 		APISpec:          modifiedSpec,
 		AuthPolicy:       authPolicy,
+		Description:      api.Description,
 		ID:               fmt.Sprint(asset.ID),
 		Image:            icon,
 		ImageContentType: iconContentType,
@@ -197,7 +203,7 @@ func (s *serviceHandler) getServiceDetail(asset *anypoint.Asset, api *anypoint.A
 		Title:            asset.ExchangeAssetName,
 		Version:          api.ProductVersion,
 		SubscriptionName: subSchName,
-		Status:           apic.PublishedStatus,
+		Status:           status,
 	}, nil
 }
 
@@ -524,10 +530,10 @@ func isPublished(api *anypoint.API, authPolicy string, c cache.Cache) (bool, str
 	}
 }
 
-func getMapFromInterface(generic interface{}) map[string]interface{} {
-	conf, ok := generic.(map[string]interface{})
+func getMapFromInterface(item interface{}) map[string]interface{} {
+	conf, ok := item.(map[string]interface{})
 	if !ok {
-		logrus.Errorf("unable to perform type assertion on %#v", generic)
+		logrus.Errorf("unable to perform type assertion on %#v", item)
 		return map[string]interface{}{}
 	}
 	return conf

--- a/pkg/discovery/servicehandler_test.go
+++ b/pkg/discovery/servicehandler_test.go
@@ -370,6 +370,7 @@ func Test_getAuthPolicy(t *testing.T) {
 			policies: anypoint.Policies{
 				Policies: []anypoint.Policy{
 					{
+						Configuration: map[string]interface{}{},
 						Template: anypoint.Template{
 							AssetID: anypoint.ClientID,
 						},
@@ -383,6 +384,7 @@ func Test_getAuthPolicy(t *testing.T) {
 			policies: anypoint.Policies{
 				Policies: []anypoint.Policy{
 					{
+						Configuration: map[string]interface{}{},
 						Template: anypoint.Template{
 							AssetID: anypoint.ExternalOauth,
 						},
@@ -396,10 +398,25 @@ func Test_getAuthPolicy(t *testing.T) {
 			policies: anypoint.Policies{
 				Policies: []anypoint.Policy{
 					{
+						Configuration: map[string]interface{}{},
 						Template: anypoint.Template{
 							AssetID: "fake",
 						},
 					},
+					{
+						Configuration: map[string]interface{}{},
+						Template: anypoint.Template{
+							AssetID: anypoint.ClientID,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "should return a map for the configuration when it is not set.'",
+			expected: apic.Apikey,
+			policies: anypoint.Policies{
+				Policies: []anypoint.Policy{
 					{
 						Template: anypoint.Template{
 							AssetID: anypoint.ClientID,
@@ -416,8 +433,9 @@ func Test_getAuthPolicy(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			policy, _, _ := getAuthPolicy(tc.policies)
+			policy, conf, _ := getAuthPolicy(tc.policies)
 			assert.Equal(t, policy, tc.expected)
+			assert.NotNil(t, conf)
 		})
 	}
 }


### PR DESCRIPTION
Change the Policy.Configuration field to be an interface to account for the field being a map, or a slice.