### PR TITLE
group endpoints for duplicate instances

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,6 +1,10 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
 
 const (
 	AttrAPIID          = "API ID"
@@ -13,4 +17,44 @@ const (
 // FormatAPICacheKey ensure consistent naming of the cache key for an API.
 func FormatAPICacheKey(apiID, stageName string) string {
 	return fmt.Sprintf("%s-%s", apiID, stageName)
+}
+
+// FormatEndpointKey key to use to look up endpoints for a service
+func FormatEndpointKey(assetID, productVersion, assetVersion string) string {
+	return fmt.Sprintf("%s-%s-%s", assetID, productVersion, assetVersion)
+}
+
+// ParseEndpoint parses an endpoint
+func ParseEndpoint(endpointURL string) (host, basePath, scheme string, port int32, err error) {
+	endpoint, err := url.Parse(endpointURL)
+	scheme = endpoint.Scheme
+	if err != nil {
+		return "", "", "", 0, err
+	}
+
+	basePath = ""
+	if endpoint.Path == "" {
+		basePath = "/"
+	} else {
+		basePath = endpoint.Path
+	}
+
+	var portInt int
+	if scheme == "http" {
+		portInt = 80
+	} else {
+		portInt = 443
+	}
+
+	strPort := endpoint.Port()
+	if strPort != "" {
+		portInt, err = strconv.Atoi(strPort)
+		if err != nil {
+			return "", "", "", 0, err
+		}
+	}
+
+	port = int32(portInt)
+
+	return endpoint.Hostname(), basePath, scheme, port, nil
 }

--- a/pkg/discovery/publish.go
+++ b/pkg/discovery/publish.go
@@ -78,6 +78,7 @@ func BuildServiceBody(service *ServiceDetail) (apic.ServiceBody, error) {
 		SetImageContentType(service.ImageContentType).
 		SetResourceType(service.ResourceType).
 		SetServiceAttribute(service.ServiceAttributes).
+		SetServiceEndpoints(service.Endpoints).
 		SetStage(service.Stage).
 		SetState(service.State).
 		SetStatus(service.Status).

--- a/pkg/discovery/servicehandler_test.go
+++ b/pkg/discovery/servicehandler_test.go
@@ -91,9 +91,9 @@ func TestServiceHandler(t *testing.T) {
 	assert.Equal(t, apic.Apikey, item.AuthPolicy)
 	assert.Equal(t, fmt.Sprint(asset.ID), item.ID)
 	assert.Equal(t, apic.Oas3, item.ResourceType)
-	assert.Equal(t, api.ProductVersion, item.Stage)
+	assert.Equal(t, api.AssetVersion, item.Stage)
 	assert.Equal(t, asset.ExchangeAssetName, item.Title)
-	assert.Equal(t, api.ProductVersion, item.Version)
+	assert.Equal(t, api.AssetVersion, item.Version)
 	assert.Equal(t, api.Tags, item.Tags)
 	assert.NotEmpty(t, item.ServiceAttributes[common.AttrChecksum])
 	assert.Equal(t, fmt.Sprint(api.ID), item.ServiceAttributes[common.AttrAPIID])
@@ -191,7 +191,8 @@ func TestServiceHandlerGetPolicyError(t *testing.T) {
 		cache:               cache.New(),
 		subscriptionManager: &mockSchemaHandler{},
 	}
-	sd, err := sh.getServiceDetail(&asset, &asset.APIs[0])
+	endpoints := endpointsMap{}
+	sd, err := sh.getServiceDetail(&asset, &asset.APIs[0], endpoints)
 
 	assert.Nil(t, sd)
 	assert.Equal(t, expectedErr, err)
@@ -212,7 +213,8 @@ func TestServiceHandlerGetExchangeAssetError(t *testing.T) {
 		subscriptionManager: &mockSchemaHandler{},
 		cache:               cache.New(),
 	}
-	sd, err := sh.getServiceDetail(&asset, &asset.APIs[0])
+	endpoints := endpointsMap{}
+	sd, err := sh.getServiceDetail(&asset, &asset.APIs[0], endpoints)
 
 	assert.Nil(t, sd)
 	assert.Equal(t, expectedErr, err)

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -1,6 +1,9 @@
 package discovery
 
-import "github.com/Axway/agents-mulesoft/pkg/anypoint"
+import (
+	"github.com/Axway/agent-sdk/pkg/apic"
+	"github.com/Axway/agents-mulesoft/pkg/anypoint"
+)
 
 // ServiceDetail is the information for the ex
 type ServiceDetail struct {
@@ -10,6 +13,7 @@ type ServiceDetail struct {
 	AuthPolicy        string
 	Description       string
 	Documentation     []byte
+	Endpoints         []apic.EndpointDefinition
 	ID                string
 	Image             string
 	ImageContentType  string


### PR DESCRIPTION
resolves #44 

- Mulesoft instances of an API can reflect different contracts of an API. If two instances are found to be the same, meaning they have the same Asset Name, Product Version and Asset Version, then they have the same contract, and they should be reflected in one API Service Revision with the endpoints contained in one API Service Instance.
- If an API has the same Asset Name, the same Product Version, but a different Asset Version, then may be a different contract, so we will publish it as a new API Service Revision.