### PR TITLE
Update to latest Agent SDK version + add usage report flags compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ run-trace:
 	@go run ./cmd/traceability/main.go
 
 build-discovery:
-	@go build -o bin/discovery ./cmd/discovery/main.go
+	@go build -o ${WORKSPACE}/bin/discovery ${WORKSPACE}/cmd/discovery/main.go
 
 build-trace:
-	@go build -o bin/traceability ./cmd/traceability/main.go
+	@go build -ldflags="-X 'github.com/Axway/agent-sdk/pkg/cmd.BuildDataPlaneType=AgentSDK'" -o ${WORKSPACE}/bin/traceability ${WORKSPACE}/cmd/traceability/main.go
 
 build-trace-docker:
 	@go build -o /app/traceability ./cmd/traceability/main.go

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Axway/agents-mulesoft
 go 1.13
 
 require (
-	github.com/Axway/agent-sdk v1.0.20210521-0.20210603162516-ae58ecf7e8c7
+	github.com/Axway/agent-sdk v1.0.20210616
 	github.com/Shopify/sarama v1.26.4 // indirect
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a/go.mod h1:tkZo8
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Axway/agent-sdk v1.0.20210521-0.20210603162516-ae58ecf7e8c7 h1:mPyS3RMKHGIsoyCQ0aLsLdLm5ZEz5LFN+iZdpj/IGMM=
 github.com/Axway/agent-sdk v1.0.20210521-0.20210603162516-ae58ecf7e8c7/go.mod h1:Wf9j81100mlfE9UxLD/SJ50tjayKzqx40OsSkoUpC/0=
+github.com/Axway/agent-sdk v1.0.20210616 h1:7Zc3jFzU3ocNO/1TIK/lYSaDMkVnFvgdTi0palEvk00=
+github.com/Axway/agent-sdk v1.0.20210616/go.mod h1:Wf9j81100mlfE9UxLD/SJ50tjayKzqx40OsSkoUpC/0=
 github.com/Azure/azure-amqp-common-go/v3 v3.0.0/go.mod h1:SY08giD/XbhTz07tJdpw1SoxQXHPN30+DI3Z04SYqyg=
 github.com/Azure/azure-event-hubs-go/v3 v3.1.2/go.mod h1:hR40byNJjKkS74+3RhloPQ8sJ8zFQeJ920Uk3oYY0+k=
 github.com/Azure/azure-pipeline-go v0.1.8/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=


### PR DESCRIPTION
This Pull Request has the following improvement:
 - update to latest SDK version 1.0.20210626
 - add the flags for reporting the Mulesoft Usage to Amplify Platform