### PR TITLE
APIGOV-DG000 - fix NPE on spec.components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/Axway/agent-sdk v1.1.89
+	github.com/Axway/agent-sdk v1.1.90-0.20240703131051-2f7d0eeca272
 	github.com/elastic/beats/v7 v7.17.20
 	github.com/getkin/kin-openapi v0.125.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Axway/agent-sdk v1.1.89 h1:YEtScppqRLbX730g1RAzwgoMP45dnJCOdPluphQYk3Q=
 github.com/Axway/agent-sdk v1.1.89/go.mod h1:LvcLFYbRJnI1iWXpkK01mSdMMwoIKd49M5Aik07gZhM=
+github.com/Axway/agent-sdk v1.1.90-0.20240703131051-2f7d0eeca272 h1:x/cKr0Lc5PflLlWlgTdQBh/N/0mssv61Vf/D5BYNs+Q=
+github.com/Axway/agent-sdk v1.1.90-0.20240703131051-2f7d0eeca272/go.mod h1:LvcLFYbRJnI1iWXpkK01mSdMMwoIKd49M5Aik07gZhM=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v12.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=

--- a/pkg/discovery/servicehandler.go
+++ b/pkg/discovery/servicehandler.go
@@ -351,7 +351,7 @@ func setOAS2policies(swagger *openapi2.T, configuration map[string]interface{}) 
 			}
 			swagger.SecurityDefinitions[common.BasicAuthName] = &ss
 			swagger.Security = append(swagger.Security, map[string][]string{
-				common.BasicAuthName: []string{},
+				common.BasicAuthName: {},
 			})
 
 		case apic.Oauth:
@@ -371,7 +371,7 @@ func setOAS2policies(swagger *openapi2.T, configuration map[string]interface{}) 
 				})
 			} else {
 				swagger.Security = append(swagger.Security, map[string][]string{
-					common.Oauth2Name: []string{},
+					common.Oauth2Name: {},
 				})
 			}
 
@@ -390,6 +390,9 @@ func setOAS2policies(swagger *openapi2.T, configuration map[string]interface{}) 
 }
 
 func setOAS3policies(spec *openapi3.T, configuration map[string]interface{}) ([]byte, error) {
+	if spec.Components == nil {
+		spec.Components = &openapi3.Components{}
+	}
 	// remove existing security
 	spec.Components.SecuritySchemes = make(openapi3.SecuritySchemes)
 	spec.Security = *openapi3.NewSecurityRequirements()

--- a/pkg/discovery/servicehandler_test.go
+++ b/pkg/discovery/servicehandler_test.go
@@ -435,7 +435,7 @@ func TestSetPolicies(t *testing.T) {
 				Info: &openapi3.Info{
 					Title: "petstore3",
 				},
-				Paths:   openapi3.Paths{},
+				Paths:   &openapi3.Paths{},
 				Servers: openapi3.Servers{{URL: "http://google.com"}},
 			},
 			expectedContent: map[string]interface{}{
@@ -479,7 +479,7 @@ func TestSetPolicies(t *testing.T) {
 				Info: &openapi3.Info{
 					Title: "petstore3",
 				},
-				Paths:   openapi3.Paths{},
+				Paths:   &openapi3.Paths{},
 				Servers: openapi3.Servers{{URL: "http://google.com"}},
 			},
 			expectedContent: map[string]interface{}{
@@ -528,7 +528,7 @@ func TestSetPolicies(t *testing.T) {
 				Info: &openapi3.Info{
 					Title: "petstore3",
 				},
-				Paths:   openapi3.Paths{},
+				Paths:   &openapi3.Paths{},
 				Servers: openapi3.Servers{{URL: "http://google.com"}},
 			},
 			expectedContent: map[string]interface{}{


### PR DESCRIPTION
This solves a NPE due to a struct from the kin.openapi package having a field changed to a pointer