### PR TITLE
APIGOV-28475 - TA config optimization

### DIFF
--- a/build/mulesoft_traceability_agent.yml
+++ b/build/mulesoft_traceability_agent.yml
@@ -12,10 +12,12 @@ mulesoft_traceability_agent:
     platformURL: ${CENTRAL_PLATFORMURL:https://platform.axway.com}
     reportActivityFrequency: ${CENTRAL_REPORTACTIVITYFREQUENCY:5m}
     versionChecker: ${CENTRAL_VERSIONCHECKER:true}
+    metricReporting:
+      publish: ${CENTRAL_METRICREPORTING_PUBLISH}
+      schedule: ${CENTRAL_METRICREPORTING_SCHEDULE}
     usageReporting:
       publish: ${CENTRAL_USAGEREPORTING_PUBLISH}
-      publishMetric: ${CENTRAL_USAGEREPORTING_PUBLISHMETRIC}
-      interval: ${CENTRAL_USAGEREPORTING_INTERVAL}
+      schedule: ${CENTRAL_USAGEREPORTING_SCHEDULE}
       offline: ${CENTRAL_USAGEREPORTING_OFFLINE}
       offlineSchedule: ${CENTRAL_USAGEREPORTING_OFFLINESCHEDULE}
     auth:
@@ -114,10 +116,10 @@ output.traceability:
       sanitize: ${TRACEABILITY_REDACTION_RESPONSEHEADER_SANITIZE:[]}
     maskingCharacters: ${TRACEABILITY_REDACTION_MASKING_CHARACTERS:"\u007B*\u007D"} # unicode for {*}
   sampling:
-    percentage: ${TRACEABILITY_SAMPLING_PERCENTAGE:10}
+    percentage: ${TRACEABILITY_SAMPLING_PERCENTAGE:0}
     per_api: ${TRACEABILITY_SAMPLING_PER_API:true}
     per_subscription: ${TRACEABILITY_SAMPLING_PER_SUBSCRIPTION:true}
-    reportAllErrors: ${TRACEABILITY_SAMPLING_REPORTALLERRORS:true}
+    onlyErrors: ${TRACEABILITY_SAMPLING_ONLYERRORS:false}
   apiExceptionsList: ${TRACEABILITY_EXCEPTION_LIST:[]}
 
 logging:


### PR DESCRIPTION
- Use CENTRAL_METRICREPORTING_PUBLISH and CENTRAL_METRICREPORTING_SCHEDULE for configuring metric event processing
- Remove TRACEABILITY_SAMPLING_REPORTALLERRORS and use TRACEABILITY_SAMPLING_ONLYERRORS
- Replace CENTRAL_USAGEREPORTING_USAGESCHEDULE with CENTRAL_USAGEREPORTING_SCHEDULE